### PR TITLE
esx 5.0 issues resolved

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -261,9 +261,6 @@ class vmwaretools (
         ensure  => $package_ensure,
       }
 
-      file { "/etc/vmware-tools/tools.conf":
-        ensure => present
-      } ->
       file_line { 'disable-tools-version':
         path    => '/etc/vmware-tools/tools.conf',
         line    => $disable_tools_version ? {


### PR DESCRIPTION
The vmwaretools Puppet module fails on esx 5.0 because a Regex that does not include 5.0
