### PR TITLE
Make symlinks for pam-modules to make the vmware-tools-pam work on RH…

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -287,7 +287,7 @@ class vmwaretools (
              creates => '/lib/security/pam_unix2.so'
           }
 	  # same for 64bit pam-libs
-	   exec { "symlink /lib54/security/pam_unix2.so":
+	   exec { "symlink /lib64/security/pam_unix2.so":
 	     command => '/bin/ln -s /lib64/security/pam_unix.so /lib64/security/pam_unix2.so',
              onlyif => '/usr/bin/test -f /lib64/security/pam_unix.so',
              creates => '/lib64/security/pam_unix2.so'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -276,6 +276,23 @@ class vmwaretools (
           require => Package[$package_real],
           notify  => Service[$service_name_real],
         }
+	if ($::osfamily == 'RedHat') and ($vmwaretools::params::majdistrelease == '6') {
+	   # the rpms provided by vmware install a PAM-Service. This pam-service
+           # references modules not provided by RH. See https://access.redhat.com/solutions/977793
+	   # create symlinks to make the service working again.
+           # check if 32bit pam-libs installed and if so make symlink for /etc/pam.d/vmtoolsd working
+	   exec { "symlink /lib/security/pam_unix2.so":
+	     command => '/bin/ln -s /lib/security/pam_unix.so /lib/security/pam_unix2.so',
+             onlyif => '/usr/bin/test -f /lib/security/pam_unix.so',
+             creates => '/lib/security/pam_unix2.so'
+          }
+	  # same for 64bit pam-libs
+	   exec { "symlink /lib54/security/pam_unix2.so":
+	     command => '/bin/ln -s /lib64/security/pam_unix.so /lib64/security/pam_unix2.so',
+             onlyif => '/usr/bin/test -f /lib64/security/pam_unix.so',
+             creates => '/lib64/security/pam_unix2.so'
+          }
+        }
 
         if ($::osfamily == 'RedHat') and ($vmwaretools::params::majdistrelease == '6') and ($rhel_upstart == true) {
           # VMware-tools 5.1 on EL6 is now using upstart and not System V init.


### PR DESCRIPTION
The RPMs shipped by Vmware install a PAM-Service /etc/pam.d/vmtoolsd which references pam_unix2.so - which is not shipped by RH. RH suggests in its knowledgebase to either make a symlink or prefix the offending line with "-". In our tests the symlinks seems to work better.