### PR TITLE
added gpgkey_url parameter

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -34,6 +34,11 @@
 #   or completely replace it.  Only works if *repopath* is specified.
 #   Default: 0 (false)
 #
+# [*gpgkey_url*]
+#   The URL where the public GPG key resides for the repository NOT including
+#   the GPG public key file itself (ending with a trailing /).
+#   Default: ${reposerver}${repopath}/
+#
 # [*priority*]
 #   Give packages in this repository a different weight.  Requires
 #   yum-plugin-priorities to be installed.
@@ -130,6 +135,7 @@ class vmwaretools (
   $just_prepend_repopath = $vmwaretools::params::safe_just_prepend_repopath,
   $priority              = $vmwaretools::params::repopriority,
   $protect               = $vmwaretools::params::repoprotect,
+  $gpgkey_url            = $vmwaretools::params::gpgkey_url,
   $proxy                 = $vmwaretools::params::proxy,
   $proxy_username        = $vmwaretools::params::proxy_username,
   $proxy_password        = $vmwaretools::params::proxy_password,
@@ -258,6 +264,7 @@ class vmwaretools (
             reposerver            => $real_reposerver,
             repopath              => $real_repopath,
             just_prepend_repopath => $real_just_prepend_repopath,
+            gpgkey_url            => $gpgkey_url,
             priority              => $priority,
             protect               => $protect,
             proxy                 => $proxy,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -38,6 +38,11 @@ class vmwaretools::params {
     default => $::vmwaretools_repoprotect,
   }
 
+  $gpgkey_url = $::vmwaretools_gpgkey_url ? {
+    undef   => "${reposerver}${repopath}/",
+    default => $::vmwaretools_gpgkey_url,
+  }
+
   $proxy = $::vmwaretools_proxy ? {
     undef   => 'absent',
     default => $::vmwaretools_proxy,

--- a/spec/classes/vmwaretools_init_spec.rb
+++ b/spec/classes/vmwaretools_init_spec.rb
@@ -83,6 +83,7 @@ describe 'vmwaretools', :type => 'class' do
       :just_prepend_repopath => 'false',
       :priority              => '50',
       :protect               => '0',
+      :gpgkey_url            => 'http://packages.vmware.com/tools/',
       :proxy                 => 'absent',
       :proxy_username        => 'absent',
       :proxy_password        => 'absent',

--- a/spec/classes/vmwaretools_repo_spec.rb
+++ b/spec/classes/vmwaretools_repo_spec.rb
@@ -158,6 +158,13 @@ describe 'vmwaretools::repo', :type => 'class' do
       )}
     end
 
+    describe 'gpgkey_url => http://localhost:8000/custom/path/' do
+      let(:params) {{ :gpgkey_url => 'http://localhost:8000/custom/path/' }}
+      it { should contain_yumrepo('vmware-tools').with(
+        :gpgkey   => "http://localhost:8000/custom/path/VMWARE-PACKAGING-GPG-DSA-KEY.pub\n    http://localhost:8000/custom/path/VMWARE-PACKAGING-GPG-RSA-KEY.pub"
+      )}
+    end
+
     describe 'reposerver => http://localhost:8000 and repopath => /some/path' do
       let :params do {
         :reposerver => 'http://localhost:8000',


### PR DESCRIPTION
This turns the `$gpgkey_url` variable into a parameter that the user can then specify a custom URL to the GPG key in case the GPG key is not hosted under the previously assumed URLs: `${yum_server}${yum_path}/keys/` or `${yum_server}${yum_path}/`