### PR TITLE
Fix rpm gpg-key import

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -196,7 +196,7 @@ class vmwaretools::repo (
 
           exec { 'vmware-import-gpgkey':
             path        => '/bin:/usr/bin:/sbin:/usr/sbin',
-            command     => "rpm --import ${gpgkey_url}VMWARE-PACKAGING-GPG-RSA-KEY.pub",
+            command     => "rpm --import ${gpgkey}",
             refreshonly => true,
           }
         }


### PR DESCRIPTION
This fixes the gpg-key import for the rpm repository on SLES.
This was only tested on SLES11sp3, but should work on other versions.