### PR TITLE
Allow puppetlabs-apt 2.x

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -19,7 +19,7 @@
     },
     {
       "name": "puppetlabs/apt",
-      "version_requirement": "1.x"
+      "version_requirement": "<3.0.0"
     },
     {
       "name": "wolfspyre/vmware_puppetfact",


### PR DESCRIPTION
Requiring puppetlabs-apt 1.x is causing dependency resolution errors with a lot of other modules.