### PR TITLE
I was having the same issue. I changed lines 319-322 in vmwaretools\m…

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -341,11 +341,11 @@ class vmwaretools (
             ensure     => $service_ensure_real,
             hasrestart => true,
             hasstatus  => true,
-	    start      => "service ${service_name_real} start",
+            start      => "service ${service_name_real} start",
             stop       => "service ${service_name_real} stop",
             status     => "service ${service_name_real} status",
             restart    => "service ${service_name_real} restart",            
-	    require    => Package[$package_real],
+            require    => Package[$package_real],
           }
         } else {
           service { $service_name_real :

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -341,10 +341,10 @@ class vmwaretools (
             ensure     => $service_ensure_real,
             hasrestart => true,
             hasstatus  => true,
-            start      => "service ${service_name_real} start",
-            stop       => "service ${service_name_real} stop",
-            status     => "service ${service_name_real} status",
-            restart    => "service ${service_name_real} restart",
+            start      => "/sbin/service ${service_name_real} start",
+            stop       => "/sbin/service ${service_name_real} stop",
+            status     => "/sbin/service ${service_name_real} status",
+            restart    => "/sbin/service ${service_name_real} restart",
             require    => Package[$package_real],
           }
         } else {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -344,7 +344,7 @@ class vmwaretools (
             start      => "service ${service_name_real} start",
             stop       => "service ${service_name_real} stop",
             status     => "service ${service_name_real} status",
-            restart    => "service ${service_name_real} restart",            
+            restart    => "service ${service_name_real} restart",
             require    => Package[$package_real],
           }
         } else {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -341,11 +341,11 @@ class vmwaretools (
             ensure     => $service_ensure_real,
             hasrestart => true,
             hasstatus  => true,
-            start      => "/sbin/start ${service_name_real}",
-            stop       => "/sbin/stop ${service_name_real}",
-            status     => "/sbin/status ${service_name_real} | grep -q 'start/'",
-            restart    => "/sbin/restart ${service_name_real}",
-            require    => Package[$package_real],
+	    start      => "service ${service_name_real} start",
+            stop       => "service ${service_name_real} stop",
+            status     => "service ${service_name_real} status",
+            restart    => "service ${service_name_real} restart",            
+	    require    => Package[$package_real],
           }
         } else {
           service { $service_name_real :

--- a/spec/classes/vmwaretools_init_spec.rb
+++ b/spec/classes/vmwaretools_init_spec.rb
@@ -145,7 +145,7 @@ describe 'vmwaretools', :type => 'class' do
       )}
       it { should contain_package('vmware-tools-esx-kmods') }
       it { should_not contain_service('vmware-tools-services').with_pattern('vmtoolsd') }
-      it { should contain_service('vmware-tools-services').with_start('/sbin/start vmware-tools-services') }
+      it { should contain_service('vmware-tools-services').with_start('/sbin/service vmware-tools-services start') }
       it { should contain_file('/etc/udev/rules.d/99-vmware-scsi-udev.rules').with(
         :content => "#\n# VMware SCSI devices Timeout adjustment\n#\n# Modify the timeout value for VMware SCSI devices so that\n# in the event of a failover, we don't time out.\n# See Bug 271286 for more information.\n\n\nACTION==\"add\", SUBSYSTEMS==\"scsi\", ATTRS{vendor}==\"VMware  \", ATTRS{model}==\"Virtual disk    \", RUN+=\"/bin/sh -c 'echo 14400 >/sys$DEVPATH/timeout'\"\nACTION==\"add\", SUBSYSTEMS==\"scsi\", ATTRS{vendor}==\"VMware, \", ATTRS{model}==\"VMware Virtual S\", RUN+=\"/bin/sh -c 'echo 14400 >/sys$DEVPATH/timeout'\"\n\n"
       ) }
@@ -229,7 +229,7 @@ describe 'vmwaretools', :type => 'class' do
       it { should contain_package('vmware-tools-esx-nox') }
       it { should contain_package('vmware-tools-esx-kmods') }
       it { should contain_service('vmware-tools-services').with_pattern('vmtoolsd') }
-      it { should_not contain_service('vmware-tools-services').with_start('/sbin/start vmware-tools-services') }
+      it { should_not contain_service('vmware-tools-services').with_start('/sbin/service vmware-tools-services start') }
     end
 
     describe 'tools_version => 5.1 and operatingsystem => RedHat 6' do
@@ -238,7 +238,7 @@ describe 'vmwaretools', :type => 'class' do
       it { should contain_package('vmware-tools-esx-nox') }
       it { should contain_package('vmware-tools-esx-kmods') }
       it { should_not contain_service('vmware-tools-services').with_pattern('vmtoolsd') }
-      it { should contain_service('vmware-tools-services').with_start('/sbin/start vmware-tools-services') }
+      it { should contain_service('vmware-tools-services').with_start('/sbin/service vmware-tools-services start') }
     end
 
     describe 'tools_version => 5.5p02 and operatingsystem => RedHat 6' do
@@ -247,7 +247,7 @@ describe 'vmwaretools', :type => 'class' do
       it { should contain_package('vmware-tools-esx-nox') }
       it { should contain_package('vmware-tools-esx-kmods') }
       it { should_not contain_service('vmware-tools-services').with_pattern('vmtoolsd') }
-      it { should contain_service('vmware-tools-services').with_start('/sbin/start vmware-tools-services') }
+      it { should contain_service('vmware-tools-services').with_start('/sbin/service vmware-tools-services start') }
     end
 
     describe 'tools_version => 5.1 and operatingsystem => SLES' do

--- a/spec/classes/vmwaretools_init_spec.rb
+++ b/spec/classes/vmwaretools_init_spec.rb
@@ -229,7 +229,7 @@ describe 'vmwaretools', :type => 'class' do
       it { should contain_package('vmware-tools-esx-nox') }
       it { should contain_package('vmware-tools-esx-kmods') }
       it { should contain_service('vmware-tools-services').with_pattern('vmtoolsd') }
-      it { should_not contain_service('vmware-tools-services').with_start('/sbin/service vmware-tools-services start') }
+      it { should_not contain_service('vmware-tools-services').with_start('/sbin/start vmware-tools-services start') }
     end
 
     describe 'tools_version => 5.1 and operatingsystem => RedHat 6' do


### PR DESCRIPTION
Services we're not starting on RHEL 6.8

Update …anifests\init.pp from:

```
        start      => "/sbin/start ${service_name_real}",
        stop       => "/sbin/stop ${service_name_real}",
        status     => "/sbin/status ${service_name_real} | grep -q 'start/'",
        restart    => "/sbin/restart ${service_name_real}",
```

to:

```
        start      => "service ${service_name_real} start",
        stop       => "service ${service_name_real} stop",
        status     => "service ${service_name_real} status",
        restart    => "service ${service_name_real} restart",
```

It now works properly.
