### PR TITLE
Support strict_vars for Puppet 4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,7 @@ group :development, :unit_tests do
   gem 'puppet-lint-empty_string-check',       :require => false
   gem 'puppet-lint-leading_zero-check',       :require => false
   gem 'puppet-lint-variable_contains_upcase', :require => false
+  gem 'gettext-setup', '< 0.16',              :require => false
 end
 
 if facterversion = ENV['FACTER_GEM_VERSION']

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -214,7 +214,7 @@ class vmwaretools (
     $real_just_prepend_repopath = $just_prepend_repopath
   }
 
-  case $facts['virtual'] {
+  case $::virtual {
     'vmware': {
       if $supported {
         $service_pattern = $tools_version ? {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -133,11 +133,11 @@
 #
 class vmwaretools (
   $tools_version         = $vmwaretools::params::tools_version,
-  $disable_tools_version = $vmwaretools::params::safe_disable_tools_version,
-  $manage_repository     = $vmwaretools::params::safe_manage_repository,
+  $disable_tools_version = $vmwaretools::params::disable_tools_version,
+  $manage_repository     = $vmwaretools::params::manage_repository,
   $reposerver            = $vmwaretools::params::reposerver,
   $repopath              = $vmwaretools::params::repopath,
-  $just_prepend_repopath = $vmwaretools::params::safe_just_prepend_repopath,
+  $just_prepend_repopath = $vmwaretools::params::just_prepend_repopath,
   $priority              = $vmwaretools::params::repopriority,
   $protect               = $vmwaretools::params::repoprotect,
   $gpgkey_url            = $vmwaretools::params::gpgkey_url,
@@ -145,13 +145,13 @@ class vmwaretools (
   $proxy_username        = $vmwaretools::params::proxy_username,
   $proxy_password        = $vmwaretools::params::proxy_password,
   $ensure                = $vmwaretools::params::ensure,
-  $autoupgrade           = $vmwaretools::params::safe_autoupgrade,
+  $autoupgrade           = $vmwaretools::params::autoupgrade,
   $package               = $vmwaretools::params::package,
   $service_ensure        = $vmwaretools::params::service_ensure,
   $service_name          = $vmwaretools::params::service_name,
-  $service_enable        = $vmwaretools::params::safe_service_enable,
+  $service_enable        = $vmwaretools::params::service_enable,
   $service_hasstatus     = $vmwaretools::params::service_hasstatus,
-  $service_hasrestart    = $vmwaretools::params::safe_service_hasrestart,
+  $service_hasrestart    = $vmwaretools::params::service_hasrestart,
   $scsi_timeout          = $vmwaretools::params::scsi_timeout,
 
   # Deprecated parameters
@@ -214,7 +214,7 @@ class vmwaretools (
     $real_just_prepend_repopath = $just_prepend_repopath
   }
 
-  case $::virtual {
+  case $facts['virtual'] {
     'vmware': {
       if $supported {
         $service_pattern = $tools_version ? {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -18,154 +18,52 @@
 class vmwaretools::params {
   # If we have a top scope variable defined, use it, otherwise fall back to a
   # hardcoded value.
-  $reposerver = $::vmwaretools_reposerver ? {
-    undef   => 'http://packages.vmware.com',
-    default => $::vmwaretools_reposerver,
-  }
+  $reposerver = 'http://packages.vmware.com'
 
-  $repopath = $::vmwaretools_repopath ? {
-    undef   => '/tools',
-    default => $::vmwaretools_repopath,
-  }
+  $repopath = '/tools'
 
-  $repopriority = $::vmwaretools_repopriority ? {
-    undef   => '50',
-    default => $::vmwaretools_repopriority,
-  }
+  $repopriority = '50'
 
-  $repoprotect = $::vmwaretools_repoprotect ? {
-    undef   => '0',
-    default => $::vmwaretools_repoprotect,
-  }
+  $repoprotect = '0'
 
-  $gpgkey_url = $::vmwaretools_gpgkey_url ? {
-    undef   => "${reposerver}${repopath}/",
-    default => $::vmwaretools_gpgkey_url,
-  }
+  $gpgkey_url = "${reposerver}${repopath}/"
 
-  $proxy = $::vmwaretools_proxy ? {
-    undef   => 'absent',
-    default => $::vmwaretools_proxy,
-  }
+  $proxy = 'absent'
 
-  $proxy_username = $::vmwaretools_proxy_username ? {
-    undef   => 'absent',
-    default => $::vmwaretools_proxy_username,
-  }
+  $proxy_username = 'absent'
 
-  $proxy_password = $::vmwaretools_proxy_password ? {
-    undef   => 'absent',
-    default => $::vmwaretools_proxy_password,
-  }
+  $proxy_password = 'absent'
 
-  $tools_version = $::vmwaretools_tools_version ? {
-    undef   => 'latest',
-    default => $::vmwaretools_tools_version,
-  }
+  $tools_version = 'latest'
+
   # Validate that tools version starts with a numeral.
-  #validate_re($tools_version, '^[^3-9]\.[0-9]*')
+  validate_re($tools_version, '^([^3-9]\.[0-9]*|latest)')
 
-  $ensure = $::vmwaretools_ensure ? {
-    undef   => 'present',
-    default => $::vmwaretools_ensure,
-  }
+  $ensure = 'present'
 
-  $package = $::vmwaretools_package ? {
-    undef   => undef,
-    default => $::vmwaretools_package,
-  }
+  $package = undef
 
-  $service_ensure = $::vmwaretools_service_ensure ? {
-    undef   => 'running',
-    default => $::vmwaretools_service_ensure,
-  }
+  $service_ensure = 'running'
 
-  $service_name = $::vmwaretools_service_name ? {
-    undef   => undef,
-    default => $::vmwaretools_service_name,
-  }
+  $service_name = undef
 
-  $service_hasstatus = $::vmwaretools_service_hasstatus ? {
-    undef   => undef,
-    default => $::vmwaretools_service_hasstatus,
-  }
+  $service_hasstatus = undef
 
-  # Since the top scope variable could be a string (if from an ENC), we might
-  # need to convert it to a boolean.
-  $just_prepend_repopath = $::just_prepend_repopath ? {
-    undef   => false,
-    default => $::vmwaretools_just_prepend_repopath,
-  }
-  if is_string($just_prepend_repopath) {
-    $safe_just_prepend_repopath = str2bool($just_prepend_repopath)
-  } else {
-    $safe_just_prepend_repopath = $just_prepend_repopath
-  }
+  $just_prepend_repopath = false
 
-  $manage_repository = $::manage_repository ? {
-    undef   => true,
-    default => $::vmwaretools_manage_repository,
-  }
-  if is_string($manage_repository) {
-    $safe_manage_repository = str2bool($manage_repository)
-  } else {
-    $safe_manage_repository = $manage_repository
-  }
+  $manage_repository = true
 
-  $disable_tools_version = $::vmwaretools_disable_tools_version ? {
-    undef   => true,
-    default => $::vmwaretools_disable_tools_version,
-  }
-  if is_string($disable_tools_version) {
-    $safe_disable_tools_version = str2bool($disable_tools_version)
-  } else {
-    $safe_disable_tools_version = $disable_tools_version
-  }
+  $disable_tools_version = true
 
-  $autoupgrade = $::vmwaretools_autoupgrade ? {
-    undef   => false,
-    default => $::vmwaretools_autoupgrade,
-  }
-  if is_string($autoupgrade) {
-    $safe_autoupgrade = str2bool($autoupgrade)
-  } else {
-    $safe_autoupgrade = $autoupgrade
-  }
+  $autoupgrade = true
 
-  $service_enable = $::vmwaretools_service_enable ? {
-    undef   => true,
-    default => $::vmwaretools_service_enable,
-  }
-  if is_string($service_enable) {
-    $safe_service_enable = str2bool($service_enable)
-  } else {
-    $safe_service_enable = $service_enable
-  }
+  $service_enable = true
 
-  $service_hasrestart = $::vmwaretools_service_hasrestart ? {
-    undef   => true,
-    default => $::vmwaretools_service_hasrestart,
-  }
-  if is_string($service_hasrestart) {
-    $safe_service_hasrestart = str2bool($service_hasrestart)
-  } else {
-    $safe_service_hasrestart = $service_hasrestart
-  }
+  $service_hasrestart = true
 
-  $scsi_timeout = $::vmwaretools_scsi_timeout ? {
-    undef   => '180',
-    default => $::vmwaretools_scsi_timeout,
-  }
+  $scsi_timeout = '180'
 
-  if $::operatingsystemmajrelease { # facter 1.7+
-    $majdistrelease = $::operatingsystemmajrelease
-  } elsif $::lsbmajdistrelease {    # requires LSB to already be installed
-    $majdistrelease = $::lsbmajdistrelease
-  } elsif $::os_maj_version {       # requires stahnma/epel
-    $majdistrelease = $::os_maj_version
-  } else {
-    $majdistrelease = regsubst($::operatingsystemrelease,'^(\d+)\.(\d+)','\1')
-  }
+  $majdistrelease = regsubst($::operatingsystemrelease,'^(\d+)\.(\d+)','\1')
 
   case $::osfamily {
     'RedHat': {
@@ -269,6 +167,8 @@ class vmwaretools::params {
             'vmware-tools-esx-kmods-3.8.0-29-generic',
             #"vmware-tools-esx-kmods-${::kernelrelease}",
           ]
+          $repobasearch_4x = undef
+          $repobasearch_5x = undef
           $service_name_4x = 'vmware-tools'
           $service_name_5x = 'vmware-tools-services'
           $service_hasstatus_4x = false

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -121,7 +121,18 @@ class vmwaretools::repo (
       case $::operatingsystem {
         'RedHat', 'CentOS', 'Scientific', 'OracleLinux', 'OEL': {
           if ( $repopath == $vmwaretools::params::repopath ) or ( $just_prepend_repopath == true ) {
-            $baseurl_url = "${reposerver}${repopath}/esx/${tools_version}/${vmwaretools::params::baseurl_string}${vmwaretools::params::majdistrelease}/${repobasearch}/"
+            $baseurl_url = join([
+              $reposerver,
+              $repopath,
+              '/esx/',
+              $tools_version,
+              '/',
+              $vmwaretools::params::baseurl_string,
+              $vmwaretools::params::majdistrelease,
+              '/',
+              $repobasearch,
+              '/'
+            ], '')
           } else {
             $baseurl_url = "${reposerver}${repopath}/"
           }
@@ -130,16 +141,25 @@ class vmwaretools::repo (
           # per http://projects.puppetlabs.com/issues/8867
           if ( $gpgkey_url == $vmwaretools::params::gpgkey_url ) {
             if ( $repopath == $vmwaretools::params::repopath ) or ( $just_prepend_repopath == true ) {
-              $gpgkey = "${reposerver}${repopath}/keys/VMWARE-PACKAGING-GPG-DSA-KEY.pub\n    ${reposerver}${repopath}/keys/VMWARE-PACKAGING-GPG-RSA-KEY.pub"
+              $gpgkey = join([
+                "${reposerver}${repopath}/keys/VMWARE-PACKAGING-GPG-DSA-KEY.pub",
+                "${reposerver}${repopath}/keys/VMWARE-PACKAGING-GPG-RSA-KEY.pub"], "\n    ")
             } else {
-              $gpgkey = "${reposerver}${repopath}/VMWARE-PACKAGING-GPG-DSA-KEY.pub\n    ${reposerver}${repopath}/VMWARE-PACKAGING-GPG-RSA-KEY.pub"
+              $gpgkey = join([
+                "${reposerver}${repopath}/VMWARE-PACKAGING-GPG-DSA-KEY.pub",
+                "${reposerver}${repopath}/VMWARE-PACKAGING-GPG-RSA-KEY.pub"], "\n    ")
             }
           } else {
-            $gpgkey = "${gpgkey_url}VMWARE-PACKAGING-GPG-DSA-KEY.pub\n    ${gpgkey_url}VMWARE-PACKAGING-GPG-RSA-KEY.pub"
+            $gpgkey = join(["${gpgkey_url}VMWARE-PACKAGING-GPG-DSA-KEY.pub",
+            "${gpgkey_url}VMWARE-PACKAGING-GPG-RSA-KEY.pub"], "\n    ")
           }
 
+          $descr = join([
+            'VMware Tools', $tools_version, '-',
+            "${vmwaretools::params::baseurl_string}${vmwaretools::params::majdistrelease}",
+            $repobasearch], ' ')
           yumrepo { 'vmware-tools':
-            descr          => "VMware Tools ${tools_version} - ${vmwaretools::params::baseurl_string}${vmwaretools::params::majdistrelease} ${repobasearch}",
+            descr          => $descr,
             enabled        => $repo_enabled,
             gpgcheck       => '1',
             gpgkey         => $gpgkey,
@@ -161,7 +181,10 @@ class vmwaretools::repo (
         }
         'SLES', 'SLED': {
           if ( $repopath == $vmwaretools::params::repopath ) or ( $just_prepend_repopath == true ) {
-            $baseurl_url = "${reposerver}${repopath}/esx/${tools_version}/${vmwaretools::params::baseurl_string}${vmwaretools::params::distrelease}/${repobasearch}/"
+            $baseurl_url = join(["${reposerver}${repopath}",
+            "/esx/${tools_version}/",
+            "${vmwaretools::params::baseurl_string}${vmwaretools::params::distrelease}",
+            "/${repobasearch}/"], '')
           } else {
             $baseurl_url = "${reposerver}${repopath}/"
           }
@@ -176,8 +199,11 @@ class vmwaretools::repo (
             $gpgkey = "${gpgkey_url}VMWARE-PACKAGING-GPG-RSA-KEY.pub"
           }
 
+          $descr = join(['VMware Tools', $tools_version, '-',
+          "${vmwaretools::params::baseurl_string}${vmwaretools::params::distrelease}",
+          $repobasearch], ' ')
           zypprepo { 'vmware-tools':
-            descr       => "VMware Tools ${tools_version} - ${vmwaretools::params::baseurl_string}${vmwaretools::params::distrelease} ${repobasearch}",
+            descr       => $descr,
             enabled     => $repo_enabled,
             gpgcheck    => '1',
             gpgkey      => $gpgkey,

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -84,7 +84,7 @@ class vmwaretools::repo (
   $tools_version         = $vmwaretools::params::tools_version,
   $reposerver            = $vmwaretools::params::reposerver,
   $repopath              = $vmwaretools::params::repopath,
-  $just_prepend_repopath = $vmwaretools::params::safe_just_prepend_repopath,
+  $just_prepend_repopath = $vmwaretools::params::just_prepend_repopath,
   $priority              = $vmwaretools::params::repopriority,
   $protect               = $vmwaretools::params::repoprotect,
   $gpgkey_url            = $vmwaretools::params::gpgkey_url,

--- a/metadata.json
+++ b/metadata.json
@@ -54,10 +54,6 @@
   ],
   "requirements": [
     {
-      "name": "pe",
-      "version_requirement": "3.x"
-    },
-    {
       "name": "puppet",
       "version_requirement": ">=3.0.0 <5.0.0"
     }

--- a/spec/classes/vmwaretools_init_spec.rb
+++ b/spec/classes/vmwaretools_init_spec.rb
@@ -10,7 +10,8 @@ describe 'vmwaretools', :type => 'class' do
       :architecture           => 'i386',
       :osfamily               => 'foo',
       :operatingsystem        => 'foo',
-      :operatingsystemrelease => '1.0'
+      :operatingsystemrelease => '1.0',
+      :virtual                => 'foo'
     }
     end
     it { should_not contain_class('vmwaretools::repo') }

--- a/spec/classes/vmwaretools_init_spec.rb
+++ b/spec/classes/vmwaretools_init_spec.rb
@@ -7,6 +7,7 @@ describe 'vmwaretools', :type => 'class' do
   context 'on a non-supported osfamily' do
     let(:params) {{}}
     let :facts do {
+      :architecture           => 'i386',
       :osfamily               => 'foo',
       :operatingsystem        => 'foo',
       :operatingsystemrelease => '1.0'
@@ -29,6 +30,7 @@ describe 'vmwaretools', :type => 'class' do
   context 'on a supported osfamily, non-vmware platform' do
     let(:params) {{}}
     let :facts do {
+      :architecture           => 'i386',
       :osfamily               => 'RedHat',
       :operatingsystem        => 'RedHat',
       :operatingsystemrelease => '1.0',
@@ -52,6 +54,7 @@ describe 'vmwaretools', :type => 'class' do
   context 'on a supported osfamily, vmware platform, non-supported operatingsystem' do
     describe "for operating system Fedora" do
       let :facts do {
+        :architecture           => 'i386',
         :virtual                => 'vmware',
         :osfamily               => 'RedHat',
         :operatingsystem        => 'Fedora',
@@ -76,9 +79,11 @@ describe 'vmwaretools', :type => 'class' do
   context 'on a supported osfamily, vmware platform, default parameters' do
     let(:params) {{}}
     let :facts do {
+      :architecture              => 'i386',
       :virtual                   => 'vmware',
       :osfamily                  => 'RedHat',
       :operatingsystem           => 'RedHat',
+      :operatingsystemrelease    => '6.5',
       :operatingsystemmajrelease => '6'
     }
     end
@@ -108,6 +113,7 @@ describe 'vmwaretools', :type => 'class' do
 
     describe 'for osfamily RedHat and operatingsystem RedHat 5' do
       let :facts do {
+        :architecture              => 'i386',
         :virtual                   => 'vmware',
         :osfamily                  => 'RedHat',
         :operatingsystem           => 'RedHat',
@@ -133,6 +139,7 @@ describe 'vmwaretools', :type => 'class' do
     describe 'for osfamily RedHat and operatingsystem RedHat 6' do
       let(:params) {{ :scsi_timeout => '14400' }}
       let :facts do {
+        :architecture              => 'i386',
         :virtual                   => 'vmware',
         :osfamily                  => 'RedHat',
         :operatingsystem           => 'RedHat',
@@ -158,6 +165,7 @@ describe 'vmwaretools', :type => 'class' do
 
     describe 'for osfamily SuSE and operatingsystem SLES' do
       let :facts do {
+        :architecture              => 'i386',
         :virtual                => 'vmware',
         :osfamily               => 'SuSE',
         :operatingsystem        => 'SLES',
@@ -174,12 +182,14 @@ describe 'vmwaretools', :type => 'class' do
 
     describe 'for osfamily Debian and operatingsystem Ubuntu' do
       let :facts do {
+        :architecture              => 'i386',
         :virtual                => 'vmware',
         :osfamily               => 'Debian',
         :operatingsystem        => 'Ubuntu',
         :operatingsystemrelease => '12.04',
         :lsbdistcodename        => 'precise',
-        :lsbdistid              => 'Ubuntu'
+        :lsbdistid              => 'Ubuntu',
+        :puppetversion          => '3.8.1' # for apt module
       }
       end
       it { should contain_class('vmwaretools::repo').with(

--- a/spec/classes/vmwaretools_ntp_spec.rb
+++ b/spec/classes/vmwaretools_ntp_spec.rb
@@ -30,8 +30,10 @@ describe 'vmwaretools::ntp', :type => 'class' do
     let(:pre_condition) { "class { 'vmwaretools': package => 'RandomData' }" }
     let(:params) {{}}
     let :facts do {
+      :architecture              => 'i386',
       :osfamily                  => 'RedHat',
       :operatingsystem           => 'RedHat',
+      :operatingsystemrelease    => '6.5',
       :operatingsystemmajrelease => '6',
       :virtual                   => 'foo'
     }
@@ -49,8 +51,10 @@ describe 'vmwaretools::ntp', :type => 'class' do
       end
       let(:params) {{}}
       let :facts do {
+        :architecture              => 'i386',
         :osfamily                  => 'RedHat',
         :operatingsystem           => 'RedHat',
+        :operatingsystemrelease    => '6.5',
         :operatingsystemmajrelease => '6',
         :virtual                   => 'vmware'
       }
@@ -67,8 +71,10 @@ describe 'vmwaretools::ntp', :type => 'class' do
       end
       let(:params) {{}}
       let :facts do {
+        :architecture              => 'i386',
         :osfamily                  => 'RedHat',
         :operatingsystem           => 'RedHat',
+        :operatingsystemrelease    => '6.5',
         :operatingsystemmajrelease => '6',
         :virtual                   => 'vmware'
       }

--- a/spec/classes/vmwaretools_repo_spec.rb
+++ b/spec/classes/vmwaretools_repo_spec.rb
@@ -9,7 +9,8 @@ describe 'vmwaretools::repo', :type => 'class' do
     let :facts do {
       :osfamily               => 'foo',
       :operatingsystem        => 'foo',
-      :operatingsystemrelease => '1.0'
+      :operatingsystemrelease => '1.0',
+      :virtual                => 'foo'
     }
     end
     #it { should run.with_params("Your operating system #{osfamily} is unsupported and will not have the VMware Tools OSP installed.").and_return('Your operating system foo is unsupported and will not have the VMware Tools OSP installed.') }
@@ -23,15 +24,33 @@ describe 'vmwaretools::repo', :type => 'class' do
   suseish   = ['SLES', 'SLED']
 
   context 'on a supported osfamily, non-vmware platform' do
-    ({'RedHat' => 'CentOS', 'SuSE' => 'SLES', 'Debian' => 'Ubuntu'}).each do |osf, os|
+    #({'RedHat' => 'CentOS', 'SuSE' => 'SLES', 'Debian' => 'Ubuntu'}).each do |osf, os|
+    [
+      {
+        :osfamily => 'RedHat',
+        :operatingsystem => 'CentOS',
+        :operatingsystemrelease => '6.5'
+      },
+      {
+        :osfamily => 'SuSE',
+        :operatingsystem => 'SLES',
+        :operatingsystemrelease => '10.2'
+      },
+      {
+        :osfamily => 'Debian',
+        :operatingsystem=> 'Ubuntu',
+        :operatingsystemrelease => '12.04',
+        :lsbdistcodename => 'precise'
+      }
+    ].each do |f|
+      osf = f[:osfamily]
+      os  = f[:operatingsystem]
       describe "for osfamily #{osf} operatingsystem #{os}" do
         let(:params) {{}}
-        let :facts do {
-          :osfamily               => osf,
-          :operatingsystem        => os,
-          :operatingsystemrelease => '1.0',
+        let :facts do f.merge({
+          :architecture           => 'i386',
           :virtual                => 'foo'
-        }
+        })
         end
         it { should_not contain_yumrepo('vmware-tools') }
         it { should_not contain_file('/etc/yum.repos.d/vmware-tools.repo') }
@@ -103,7 +122,8 @@ describe 'vmwaretools::repo', :type => 'class' do
         :architecture           => 'amd64',
         :operatingsystem        => 'Ubuntu',
         :lsbdistcodename        => 'precise',
-        :lsbdistid              => 'Ubuntu'
+        :lsbdistid              => 'Ubuntu',
+        :puppetversion          => '3.8.1'
       }
       end
       it { should contain_apt__source('vmware-tools').with(


### PR DESCRIPTION
Make sure code passes spec tests when strict_vars is on.

This required removing support for passing parameters via global variables with an ENC, which has been deprecated since Puppet 3 .