### PR TITLE
Update apt module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,14 +14,14 @@ script: "bundle exec rake validate && bundle exec rake lint && bundle exec rake 
 matrix:
   fast_finish: true
   include:
-  - rvm: 1.8.7
-    env: PUPPET_GEM_VERSION="~> 3.0"
   - rvm: 1.9.3
     env: PUPPET_GEM_VERSION="~> 3.0"
   - rvm: 2.0.0
     env: PUPPET_GEM_VERSION="~> 3.0"
   - rvm: 2.0.0
     env: PUPPET_GEM_VERSION="~> 3.0" FUTURE_PARSER="yes"
+  - rvm: 2.1.9
+    env: PUPPET_GEM_VERSION="~> 4.0" STRICT_VARIABLES="no"
   - rvm: 2.1.9
     env: PUPPET_GEM_VERSION="~> 4.0"
   - rvm: 2.4.1

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -218,13 +218,25 @@ class vmwaretools::repo (
           }
 
           include '::apt'
-          apt::source { 'vmware-tools':
-            ensure     => $ensure,
-            comment    => "VMware Tools ${tools_version} - ${vmwaretools::params::baseurl_string} ${::lsbdistcodename}",
-            location   => $baseurl_url,
-            key_source => $gpgkey,
-            #key        => '0xC0B5E0AB66FD4949',
-            key        => '36E47E1CC4DCC5E8152D115CC0B5E0AB66FD4949',
+          if versioncmp($::puppetversion, '4') < 0 {
+            apt::source { 'vmware-tools':
+              ensure     => $ensure,
+              comment    => "VMware Tools ${tools_version} - ${vmwaretools::params::baseurl_string} ${::lsbdistcodename}",
+              location   => $baseurl_url,
+              key_source => $gpgkey,
+              #key        => '0xC0B5E0AB66FD4949',
+              key        => '36E47E1CC4DCC5E8152D115CC0B5E0AB66FD4949',
+            }
+          }else{
+            apt::source { 'vmware-tools':
+              ensure   => $ensure,
+              comment  => "VMware Tools ${tools_version} - ${vmwaretools::params::baseurl_string} ${::lsbdistcodename}",
+              location => $baseurl_url,
+              key      => {
+                source => $gpgkey,
+                id     => '36E47E1CC4DCC5E8152D115CC0B5E0AB66FD4949',
+              }
+            }
           }
         }
         default: { }

--- a/metadata.json
+++ b/metadata.json
@@ -19,7 +19,7 @@
     },
     {
       "name": "puppetlabs/apt",
-      "version_requirement": ">=2.0.0 <3.0.0"
+      "version_requirement": ">=2.0.0 <5.0.0"
     },
     {
       "name": "wolfspyre/vmware_puppetfact",

--- a/spec/classes/vmwaretools_init_spec.rb
+++ b/spec/classes/vmwaretools_init_spec.rb
@@ -192,6 +192,13 @@ describe 'vmwaretools', :type => 'class' do
 
     describe 'for osfamily Debian and operatingsystem Ubuntu' do
       let :facts do {
+        :os                     => {
+          :family  => 'Debian',
+          :name    => 'Ubuntu',
+          :release => {
+            :full => '12.04'
+          }
+        },
         :virtual                => 'vmware',
         :osfamily               => 'Debian',
         :operatingsystem        => 'Ubuntu',
@@ -200,7 +207,7 @@ describe 'vmwaretools', :type => 'class' do
         :architecture           => 'amd64',
         :lsbdistcodename        => 'precise',
         :lsbdistid              => 'Ubuntu',
-        :puppetversion          => '3.5.1'
+        :puppetversion          => Puppet.version
       }
       end
       it { should contain_class('vmwaretools::repo').with(

--- a/spec/classes/vmwaretools_repo_spec.rb
+++ b/spec/classes/vmwaretools_repo_spec.rb
@@ -30,6 +30,10 @@ describe 'vmwaretools::repo', :type => 'class' do
       describe "for osfamily #{osf} operatingsystem #{os}" do
         let(:params) {{}}
         let :facts do {
+          :os                     => {
+            :family  => osf,
+            :name    => os,
+          },
           :osfamily               => osf,
           :operatingsystem        => os,
           :operatingsystemrelease => '1.0',
@@ -54,6 +58,10 @@ describe 'vmwaretools::repo', :type => 'class' do
     redhatish.each do |os|
       describe "for operating system #{os}" do
         let :facts do {
+          :os                     => {
+            :family  => 'RedHat',
+            :name    => os,
+          },
           :virtual                => 'vmware',
           :osfamily               => 'RedHat',
           :operatingsystemrelease => '6.1',
@@ -82,6 +90,10 @@ describe 'vmwaretools::repo', :type => 'class' do
     suseish.each do |os|
       describe "for operating system #{os}" do
         let :facts do {
+          :os                     => {
+            :family  => 'SuSE',
+            :name    => os,
+          },
           :virtual                => 'vmware',
           :osfamily               => 'SuSE',
           :operatingsystemrelease => '10',
@@ -106,10 +118,20 @@ describe 'vmwaretools::repo', :type => 'class' do
       end
     end
 
-    describe "for operating system Ubuntu" do
+    # Get puppetversion for Ubuntu tests
+    puppetversion = Puppet.version.to_i
+
+    describe "for operating system Ubuntu Puppet 3" do
       let(:pre_condition) { "class { 'apt': }" }
       let :facts do {
         :virtual                => 'vmware',
+        :os                     => {
+          :family  => 'Debian',
+          :name    => 'Ubuntu',
+          :release => {
+            :full => '12.04'
+          }
+        },
         :osfamily               => 'Debian',
         :operatingsystemrelease => '12.04',
         :lsbmajdistrelease      => '12',
@@ -118,22 +140,65 @@ describe 'vmwaretools::repo', :type => 'class' do
         :operatingsystem        => 'Ubuntu',
         :lsbdistcodename        => 'precise',
         :lsbdistid              => 'Ubuntu',
-        :puppetversion          => '3.5.1'
+        :puppetversion          => Puppet.version
       }
       end
-      it { should contain_apt__source('vmware-tools').with(
-        :comment    => 'VMware Tools latest - ubuntu precise',
-        :ensure     => 'present',
-        :location   => 'http://packages.vmware.com/tools/esx/latest/ubuntu',
-        :key_source => 'http://packages.vmware.com/tools/keys/VMWARE-PACKAGING-GPG-RSA-KEY.pub',
-       #:key        => '0xC0B5E0AB66FD4949',
-        :key        => '36E47E1CC4DCC5E8152D115CC0B5E0AB66FD4949'
-      )}
+      if puppetversion < 4
+        it { should contain_apt__source('vmware-tools').with(
+          :comment  => 'VMware Tools latest - ubuntu precise',
+          :ensure   => 'present',
+          :location => 'http://packages.vmware.com/tools/esx/latest/ubuntu',
+          :key_source => 'http://packages.vmware.com/tools/keys/VMWARE-PACKAGING-GPG-RSA-KEY.pub',
+          #:key        => '0xC0B5E0AB66FD4949',
+          :key        => '36E47E1CC4DCC5E8152D115CC0B5E0AB66FD4949'
+        )}
+      end
+    end
+    describe "for operating system Ubuntu Puppet >= 4" do
+      let(:pre_condition) { "class { 'apt': }" }
+      let :facts do {
+        :virtual                => 'vmware',
+        :os                     => {
+          :family  => 'Debian',
+          :name    => 'Ubuntu',
+          :release => {
+            :full => '12.04'
+          }
+        },
+        :osfamily               => 'Debian',
+        :operatingsystemrelease => '12.04',
+        :lsbmajdistrelease      => '12',
+        :operatingsystemmajrelease => '12',
+        :architecture           => 'amd64',
+        :operatingsystem        => 'Ubuntu',
+        :lsbdistcodename        => 'precise',
+        :lsbdistid              => 'Ubuntu',
+        :puppetversion          => Puppet.version
+      }
+      end
+      if puppetversion > 3
+        it { should contain_apt__source('vmware-tools').with(
+          :comment  => 'VMware Tools latest - ubuntu precise',
+          :ensure   => 'present',
+          :location => 'http://packages.vmware.com/tools/esx/latest/ubuntu',
+          :key      => {
+            'source' => 'http://packages.vmware.com/tools/keys/VMWARE-PACKAGING-GPG-RSA-KEY.pub',
+            'id'     => '36E47E1CC4DCC5E8152D115CC0B5E0AB66FD4949'
+          }
+        )}
+      end
     end
   end
 
   context 'on a supported operatingsystem, vmware platform, custom parameters' do
     let :facts do {
+      :os                     => {
+        :family  => 'RedHat',
+        :name    => 'RedHat',
+        :release => {
+          :full => '6.1'
+        }
+      },
       :virtual                => 'vmware',
       :osfamily               => 'RedHat',
       :operatingsystem        => 'RedHat',


### PR DESCRIPTION
APT `version_requirement` has now allowed newer versions to be used.
Current testing is with legacy `2.4.1` version of the module until @razorsedge decides to deprecate Puppet 3 support.
When fixture is updated to `apt > 2.x` all Puppet 3 tests will fail as expected.