### PR TITLE
Update zypprepo dependency to new owner

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -3,8 +3,8 @@ fixtures:
     stdlib: "https://github.com/puppetlabs/puppetlabs-stdlib.git"
     vmware_puppetfact: "https://github.com/wolfspyre/vmware_puppetfact.git"
     zypprepo:
-      repo: "https://github.com/deadpoint/puppet-zypprepo.git"
-      ref: "v1.0.2"
+      repo: "https://github.com/voxpupuli/puppet-zypprepo.git"
+      ref: "v2.2.2"
     apt:
       repo: "https://github.com/puppetlabs/puppetlabs-apt.git"
       ref: "2.4.0"

--- a/metadata.json
+++ b/metadata.json
@@ -14,8 +14,8 @@
       "version_requirement": ">=2.3.0 <5.0.0"
     },
     {
-      "name": "darin/zypprepo",
-      "version_requirement": "1.x"
+      "name": "puppet/zypprepo",
+      "version_requirement": ">=2.0.0 <3.0.0"
     },
     {
       "name": "puppetlabs/apt",


### PR DESCRIPTION
Given the zypprepo module has also changed ownership, it makes sense to update the dependency to reference the new owner.